### PR TITLE
Adding _normal to __getstate__ and __setstate__

### DIFF
--- a/unum/core.py
+++ b/unum/core.py
@@ -555,7 +555,7 @@ class Unum(object):
     __repr__ = __str__
 
     def __getstate__(self):
-        return self._value, self._unit.copy()
+        return self._value, self._unit.copy(), self._normal
 
     def __setstate__(self, state):
-        self._value, self._unit = state
+        self._value, self._unit, self._normal = state


### PR DESCRIPTION
This fixes pickling of Unum values, as without this objects loaded via pickle are broken to do a missing _normal attribute